### PR TITLE
Convert printable numpad keys to number keys

### DIFF
--- a/iron-input.html
+++ b/iron-input.html
@@ -135,6 +135,11 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       return printable;
     },
 
+    // convert printable numpad keys to number keys
+    _correctNumpadKeys: function(keyCode) {
+      return (keyCode > 95 && keyCode < 112) ? keyCode - 48 : keyCode;
+    },
+
     _onKeydown: function(event) {
       if (!this.preventInvalidInput && this.type !== 'number') {
         return;
@@ -143,7 +148,7 @@ is separate from validation, and `allowed-pattern` does not affect how the input
       if (!regexp) {
         return;
       }
-      var thisChar = String.fromCharCode(event.keyCode);
+      var thisChar = String.fromCharCode(this._correctNumpadKeys(event.keyCode));
       if (this._isPrintable(event.keyCode) && !regexp.test(thisChar)) {
         event.preventDefault();
       }


### PR DESCRIPTION
Added _correctNumpadKeys method to convert numpad keys 97 - 112 to number keys 47 - 58. String.fromCharCode returns lower case letters a - p for numpad keys 97 - 112 making allowed-pattern="[0-9]" impossible to add via the numpad.